### PR TITLE
コンパイラ更新に向けたコンパイラオプションの追加

### DIFF
--- a/install_stm32plus.sh
+++ b/install_stm32plus.sh
@@ -10,7 +10,8 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 sudo apt-get -y install scons 1> /dev/null  &&  echo 'sconsのインストールが完了しました'
 
 cp "$SCRIPT_DIR"/stm32plus_nostlthrow_git.patch /tmp
-cd /tmp 
+cp "$SCRIPT_DIR"/stm32plus_compiler_option.patch /tmp
+cd /tmp
 
 if [ -e stm32plus ]; then
   echo "Delete old stm32plus files"
@@ -22,6 +23,7 @@ git clone https://github.com/andysworkshop/stm32plus.git
 #patch -b stm32plus/lib/include/stl/string < stm32plus_nostlthrow.patch
 cd stm32plus
 git apply ../stm32plus_nostlthrow_git.patch
+git apply ../stm32plus_compiler_option.patch
 
 if [ -e '/usr/local/arm-cs-tools/bin' ]; then
   PATH="/usr/local/arm-cs-tools/bin:$PATH"

--- a/stm32plus_compiler_option.patch
+++ b/stm32plus_compiler_option.patch
@@ -1,0 +1,24 @@
+diff --git a/SConstruct b/SConstruct
+index 798707ca..6583f1f8 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -166,8 +166,8 @@ env.Append(CPPPATH=["#lib/include","#lib/include/stl","#lib"])
+ 
+ # create the C and C++ flags that are needed. We can't use the extra or pedantic errors on the ST library code.
+ 
+-env.Replace(CCFLAGS=["-Wall","-Werror","-Wno-implicit-fallthrough","-ffunction-sections","-fdata-sections","-fno-exceptions","-mthumb","-gdwarf-2","-pipe"])
+-env.Replace(CXXFLAGS=["-Wextra","-pedantic-errors","-fno-rtti","-std=gnu++14","-fno-threadsafe-statics"])
++env.Replace(CCFLAGS=["-Wall","-Werror","-Wno-implicit-fallthrough","-ffunction-sections","-fdata-sections","-fno-exceptions","-mthumb","-gdwarf-2","-pipe","-Wno-attributes"])
++env.Replace(CXXFLAGS=["-Wextra","-pedantic-errors","-fno-rtti","-std=gnu++14","-fno-threadsafe-statics","-Wno-deprecated-copy","-Wno-cast-function-type","-Wno-address-of-packed-member","-Wno-class-memaccess"])
+ env.Append(CCFLAGS="-D"+osc_def+"="+osc)
+ env.Append(LINKFLAGS=["-Xlinker","--gc-sections","-mthumb","-g3","-gdwarf-2"])
+ 
+@@ -251,7 +251,7 @@ print("stm32plus build version is "+VERSION)
+ systemprefix=mode+"-"+mcu+"-"+osc+osc_type
+ if float:
+   systemprefix += "-"+float
+-  
++
+ # launch SConscript for the main library
+ 
+ libstm32plus=SConscript("lib/SConscript",


### PR DESCRIPTION
コンパイラ更新に向けたコンパイラオプションの追加．GCC7系以降のGCCのアップデートでいくつかの警告がデフォルトでコンパイルエラーになるよう変更がなされているようなのでそれに追従するコンパイラオプションを追加しました．これにより，aptでインストールしたarmのコンパイラを用いても(少なからずstm32plusのビルドに関しては)コンパイルが通るようになりました．