### PR TITLE
:bug: `git clone`前にGitをインストールするように修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,11 @@ if [ -e /tmp/stm32fx_template_dev_env ]; then
     rm -rf /tmp/stm32fx_template_dev_env
 fi
 
+echo -e "\e[1;32m> Git\e[m"
+echo -e "\e[90m[1/1]\e[m インストール中..."
+sudo -E apt-get -y install git -qq
+echo
+
 echo "インストーラーをダウンロードしています"
 git clone https://github.com/ForteFibre/stm32fx_template_dev_env.git stm32fx_template_dev_env -q
 cd /tmp/stm32fx_template_dev_env

--- a/install_env.sh
+++ b/install_env.sh
@@ -31,11 +31,6 @@ echo -e "\e[90m[1/1]\e[m インストール中..."
 sudo -E apt-get -y install cmake -qq
 echo
 
-echo -e "\e[1;32m> Git\e[m"
-echo -e "\e[90m[1/1]\e[m インストール中..."
-sudo -E apt-get -y install git -qq
-echo
-
 cd /tmp
 
 echo -e "\e[1;32m> stlink\e[m"


### PR DESCRIPTION
Close #29 

## 概要
エントリポイントとなる`install.sh`でGitをインストールした後、`git clone`を実行するように修正します。
