### PR TITLE
:sparkles: WSLで環境構築するスクリプトを追加

### DIFF
--- a/install_env.sh
+++ b/install_env.sh
@@ -39,10 +39,16 @@ echo
 cd /tmp
 
 echo -e "\e[1;32m> stlink\e[m"
-echo -e "\e[90m[1/2]\e[m debパッケージ取得中..."
-wget "https://github.com/stlink-org/stlink/releases/download/v1.6.1/stlink-1.6.1-1_amd64.deb" -O "stlink-1.6.1-1_amd64.deb" -q --show-progress
-echo -e "\e[90m[2/2]\e[m インストール中..."
-sudo -E apt-get -y install ./stlink-1.6.1-1_amd64.deb -qq
+if grep -q microsoft /proc/version; then
+    echo -e "\e[1;32m>> Running on WSL\e[m"
+    bash "$SCRIPT_DIR"/install_for_wsl.sh
+else
+    echo -e "\e[1;32m>> Running on native Linux\e[m"
+    echo -e "\e[90m[1/2]\e[m debパッケージ取得中..."
+    wget "https://github.com/stlink-org/stlink/releases/download/v1.6.1/stlink-1.6.1-1_amd64.deb" -O "stlink-1.6.1-1_amd64.deb" -q --show-progress
+    echo -e "\e[90m[2/2]\e[m インストール中..."
+    sudo -E apt-get -y install ./stlink-1.6.1-1_amd64.deb -qq
+fi
 echo
 
 echo -e "\e[1;32m> GNU Arm Embedded Toolchain\e[m"

--- a/install_for_wsl.sh
+++ b/install_for_wsl.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+echo -e "\e[1;32m> unzip\e[m"
+echo -e "\e[90m[1/1]\e[m インストール中..."
+sudo -E apt-get -y install unzip -qq
+echo
+
+cd /tmp
+
+echo -e "\e[1;32m> stlink for Windows\e[m"
+echo -e "\e[90m[1/2]\e[m アーカイブ取得中..."
+wget "https://github.com/stlink-org/stlink/releases/download/v1.7.0/stlink-1.7.0-x86_64-w64-mingw32.zip" -O "stlink-1.7.0-x86_64-w64-mingw32.zip" -q --show-progress
+echo -e "\e[90m[2/3]\e[m アーカイブ展開中..."
+if [ -e /tmp/stlink-1.7.0-x86_64-w64-mingw32 ]; then
+    sudo rm -rf /tmp/stlink-1.7.0-x86_64-w64-mingw32
+fi
+unzip "stlink-1.7.0-x86_64-w64-mingw32.zip" -d "stlink-1.7.0-x86_64-w64-mingw32"
+
+WINHOME=$(wslpath "$(wslvar USERPROFILE)")
+
+if [ -e "$WINHOME"/stlink-1.7.0-x86_64-w64-mingw32 ]; then
+    sudo rm -rf "$WINHOME"/stlink-1.7.0-x86_64-w64-mingw32
+fi
+
+# WSLからWindows上のファイルのパーミッションを変更出来ず、
+# Operation not permittedとなることを避けるために、事前に
+# パーミッションを合わせておく
+chmod -R 777 stlink-1.7.0-x86_64-w64-mingw32
+sudo chown -R root:root stlink-1.7.0-x86_64-w64-mingw32
+sudo mv "stlink-1.7.0-x86_64-w64-mingw32/stlink-1.7.0-x86_64-w64-mingw32" "$WINHOME"/
+echo -e "\e[90m[3/3]\e[m シンボリックリンク作成中..."
+mkdir -p ~/.local/bin
+ls "$WINHOME"/stlink-1.7.0-x86_64-w64-mingw32/bin | while read -r EXE_FILE; do
+   LINKNAME=$(basename $EXE_FILE .exe)
+   ln -fs "$WINHOME"/stlink-1.7.0-x86_64-w64-mingw32/bin/"$EXE_FILE" ~/.local/bin/"$LINKNAME"
+done


### PR DESCRIPTION
Close #31 

## 概要

WSL上で環境構築スクリプトを実行した際に、WSL向けのスクリプトを実行するようにします。
具体的には、
1. WSLのUbuntu環境には`st-link`をインストールしないようにする（WSL以外は従来の手順で`st-link`をインストールする）
2. WSLでは、代わりにWindows環境に`st-link`をインストールして、WSLから利用する

ようにスクリプトを変更しています。

Windows上の`st-flash.exe`をWSL上の`~/.local/bin`に`st-flash`でシンボリックリンクを配置しているため、従来の`Makefile`のまま`make flash`を実行出来るようになっています。